### PR TITLE
Use Debian Stretch as base for AWS Lambda GLIBC version compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,41 @@
-FROM node:16
+#-- Important : We use stretch-slim to match GLIBC 2.24 supplied on AWS Lambda
+#   This is important because this image will run serverless-python-package
+#   to package compiled python modules.  pip will pull the compiled wheel file
+#   to match the host architecture and version, and that must also match the lambda
+#   architecture and version. (abi3-manylinux_2_24_x86_64)
+
+FROM debian:stretch-slim
+
+#-- install python 3.8
+#   pipenv is pinned to ==2022.8.5 because of https://github.com/serverless/serverless-python-requirements/issues/716
+
 RUN cd /tmp \
    && apt-get update \
-   && apt-get install -y libgeos-dev libspatialindex-dev zip unzip p7zip libfreetype6-dev libpng-dev \
+   && apt-get install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev curl libbz2-dev \
+   && apt-get install -y libgeos-dev libspatialindex-dev zip unzip p7zip libfreetype6-dev libpng-dev wget git \
    && wget https://www.python.org/ftp/python/3.8.13/Python-3.8.13.tgz \
    && tar xvf Python-3.8.13.tgz \
    && cd /tmp/Python-3.8.13 \
    && ./configure --enable-optimizations --with-ensurepip=install \
    && make -j8 \
    && make altinstall \
-   && pip3.8 install pipenv awscli virtualenv --upgrade
- RUN cd /tmp \
+   && pip3.8 install pipenv==2022.8.5 awscli virtualenv --upgrade
+
+#-- install yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get install apt-transport-https
+RUN apt-get update \
+   && apt-get install -y yarn
+
+#-- install Node 16
+
+RUN (curl -fsSL https://deb.nodesource.com/setup_16.x | bash -) \
+   && apt-get install -y nodejs
+
+#-- install packer 1.22 and packer 1.7.5
+
+RUN cd /tmp \
    && apt-get update \
    && wget https://releases.hashicorp.com/packer/1.2.2/packer_1.2.2_linux_amd64.zip -O /tmp/packer.zip \
    && mkdir ~/.bin \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+ACCOUNT:=nuonic
+NAME:=node-python-awscli
+MAJOR:=3
+MINOR:=1
+PATCH:=0
+
+build:
+	docker build -t nuonic/node-python-awscli .
+
+tag:
+	docker image tag nuonic/node-python-awscli nuonic/node-python-awscli:$(MAJOR).$(MINOR).$(PATCH)
+	docker image tag nuonic/node-python-awscli nuonic/node-python-awscli:$(MAJOR).$(MINOR)
+	docker image tag nuonic/node-python-awscli nuonic/node-python-awscli:$(MAJOR)
+
+push:
+	docker image push --all-tags $(ACCOUNT)/$(NAME)
+
+run:
+	docker run --rm -it --name buildtest --volume /Users/guycarpenter/prism:/prism --volume /Users/guycarpenter/.aws:/root/.aws nuonic/node-python-awscli:2 bash

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 ACCOUNT:=nuonic
 NAME:=node-python-awscli
 MAJOR:=3
-MINOR:=1
-PATCH:=0
+MINOR:=2
+PATCH:=2
 
 build:
 	docker build -t nuonic/node-python-awscli .
@@ -16,4 +16,4 @@ push:
 	docker image push --all-tags $(ACCOUNT)/$(NAME)
 
 run:
-	docker run --rm -it --name buildtest --volume /Users/guycarpenter/prism:/prism --volume /Users/guycarpenter/.aws:/root/.aws nuonic/node-python-awscli:2 bash
+	docker run --rm -it --name buildtest --volume /Users/guycarpenter/prism:/prism --volume /Users/guycarpenter/.aws:/root/.aws nuonic/node-python-awscli bash

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # node-python-awscli
 
-docker image containing node 14 + python 3 + awscli
+docker image containing Debian Stretch + Node 16 + python 3.8 + awscli
 
 On Docker Hub: [nuonic/node-python-awscli](https://hub.docker.com/r/nuonic/node-python-awscli)


### PR DESCRIPTION
This is intended to address the situation where compiled python modules are being packaged that are incompatible with the lambda runtime, resulting in this error:
```
 [ERROR] Runtime.ImportModuleError: Unable to import module 'handler': /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /var/task/bcrypt/_bcrypt.abi3.so)
```