### PR TITLE
Add gnu make 4.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,3 +50,11 @@ RUN cd /tmp \
     && unzip -p /tmp/packer.zip > ~/.bin/packer-1.7.5 \
     && chmod +x ~/.bin/packer-1.7.5 \
     && rm -rf /var/cache/yum /tmp/* /var/tmp/*
+
+#-- install gnu make 4.4 (for the --output-sync feature)
+
+RUN wget https://ftp.gnu.org/gnu/make/make-4.4.tar.gz -O - | tar -vzxf - -C /tmp \
+    && cd /tmp/make-4.4 \
+    && ./configure \
+    && make install
+    

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ACCOUNT:=nuonic
 NAME:=node-python-awscli
 MAJOR:=5
-MINOR:=0
+MINOR:=1
 PATCH:=0
 
 build:


### PR DESCRIPTION
This will allow us to run parallel make targets and still have the output separated in stdout as if they were run sequentially.